### PR TITLE
fix: add region arg to gcloud run command

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -29,7 +29,7 @@ sed -e "s/YOUR-PROJECT-ID/${PROJECT_ID}/g" \
     service.yaml > service.yaml.tmp
 
 # Deploy to Cloud Run
-gcloud run services replace service.yaml.tmp
+gcloud run services replace service.yaml.tmp --region $REGION 
 
 # Clean up the temporary file
 rm service.yaml.tmp


### PR DESCRIPTION
This arg is required if the user doesn't have the default region set for Cloud Run (and this step is not described in the README). 

Without this argument, the user is presented with a region selection list as part of their deployment.